### PR TITLE
v0.6.3: Render scaling

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,6 +209,12 @@
                                         <option value="1">1.21 Fonts</option>
                                     </select>
                                 </div>
+                                <div class="setting-container vertical">
+                                    <span>Image Render Scale</span>
+                                    <input type="range" id="render-scale" class="setting" setting="render-scale" min="1" max="5" step="1" data-format="x%s Scale">
+                                    <span id="render-scale-display" class="range-display">Infinite Scale</span>
+                                    <span class="hint">Note: Image Render Scale only works with "Copy Image" and "Download Image" buttons for now</span>
+                                </div>
                             </div>
                             <h3>Editor Settings</h3>
                             <div class="setting-section">
@@ -218,7 +224,7 @@
                                     <span id="update-period-display" class="range-display">Infinite seconds</span>
                                 </div>
                                 <div class="setting-container vertical">
-                                    <span>Canvas Scale</span>
+                                    <span>Scale</span>
                                     <input type="range" id="image-scale" class="setting" setting="image-scale" min="0.5" max="3" step="0.25" data-format="x%s Scale">
                                     <span id="image-scale-display" class="range-display">Infinite Scale</span>
                                 </div>

--- a/scripts.js
+++ b/scripts.js
@@ -147,14 +147,32 @@ class MinecraftGenerator {
 
     async getImageFromCanvas(canvas) {
         return new Promise((resolve, reject) => {
-            canvas.toBlob((blob) => {
+            let targetCanvas;
+            if (this.settings.renderScale > 1) {
+                let scaledCanvas = document.createElement("canvas");
+                scaledCanvas.style.imageRendering = "pixelated";
+                scaledCanvas.width = this.settings.renderScale * canvas.width;
+                scaledCanvas.height = this.settings.renderScale * canvas.height;
+                
+                let scaledContext = scaledCanvas.getContext("2d");
+                scaledContext.imageSmoothingEnabled = false;
+                scaledContext.mozImageSmoothingEnabled = false;
+                scaledContext.oImageSmoothingEnabled = false;
+                scaledContext.webkitImageSmoothingEnabled = false;
+                scaledContext.msImageSmoothingEnabled = false;
+                scaledContext.drawImage(canvas, 0, 0, canvas.width, canvas.height, 0, 0, scaledCanvas.width, scaledCanvas.height);
+                targetCanvas = scaledCanvas;
+            } else {
+                targetCanvas = canvas;
+            }
+            targetCanvas.toBlob((blob) => {
                 if (blob) {
                     resolve(blob);
                 } else {
                     reject(new Error("Couldn't convert the canvas to a blob"));
                 }
             })
-        })
+        });
     }
 
     async copyToClipboard() {
@@ -164,7 +182,7 @@ class MinecraftGenerator {
             await navigator.clipboard.write(data);
         } catch (error) {
             const errorData = createDebugInformation("imageDownload", error)
-            createToast("error", "There was an issue trying to download the image.", "Typically, this is", "Click me to copy relevant debug data to your clipboard", errorData);
+            createToast("error", "There was an issue trying to download the image.", "Get in contact with a developer to have them sort it out.", "Click me to copy relevant debug data to your clipboard", errorData);
         }
     }
 
@@ -942,6 +960,7 @@ class Settings {
         // image settings
         this._firstLineGap = this.loadBooleanSetting("first-line-gap", false, true);
         this._renderBackground = this.loadBooleanSetting("render-background", false, true);
+        this._renderScale = this.loadNumberSetting("render-scale", true, 1, 1, 10);
         this._fontVersion = this.loadNumberSetting("font-version", true, 0, 0, 1);
         // editor settings
         this._updatePeriod = this.loadNumberSetting("update-period", true, 2, 0, Number.MAX_SAFE_INTEGER);
@@ -962,6 +981,8 @@ class Settings {
     get updatePeriod() { return this._updatePeriod.value; }
 
     get imageScale() { return this._imageScale.value; }
+
+    get renderScale() { return this._renderScale.value; }
 
     get includeDisplayItem() { return this._includeDisplayItem.value; }
 

--- a/styles.css
+++ b/styles.css
@@ -351,6 +351,10 @@ main {
     gap: 0.5em;
 }
 
+.setting-container.vertical span {
+    text-align: center;
+}
+
 .setting-hint, .setting-container span {
     max-width: 200px;
 }

--- a/styles.css
+++ b/styles.css
@@ -447,7 +447,7 @@ input[type="checkbox"]:checked::after {
         border: 0.2em solid #123;
         cursor: ew-resize;
         background: #ffffff;
-        box-shadow: -10em 0 1em 9.25em var(--primary-600);
+        box-shadow: -20em 0 0.75em 19em var(--primary-600);
     }
 }
 
@@ -460,7 +460,7 @@ input[type="range"]::-moz-range-progress {
     height: 4em;
     width: 0;
     border: none;
-    box-shadow: -10em 0 1em 9.25em var(--primary-600);
+    box-shadow: -20em 0 0.75em 19em var(--primary-600);
     box-sizing: border-box;
 }
 


### PR DESCRIPTION
# v0.6.3: Render Scaling
- Adds the ability change the scale of rendered images through a setting.
    - Note: This only works with the Copy / Download Image buttons. Looking to control the `Right Click > Copy Image` option in the future.
<img width="308" height="322" alt="image" src="https://github.com/user-attachments/assets/4e30a5be-298f-4e42-9610-ba1eba492575" />

### Example
- Using 1x Image Render Scaling
<img width="312" height="36" alt="image" src="https://github.com/user-attachments/assets/d9dfc2f3-93e6-481a-9fa6-0a469064a37d" />

- Using 3x Image Render Scaling
<img width="924" height="108" alt="image" src="https://github.com/user-attachments/assets/a7e58e21-d3af-44ad-8053-ea8ed17d926f" />

##### (In response to Issue #27 and request in DMs)