### PR TITLE
v0.6.3.1 Render Scale Default Settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,7 +211,7 @@
                                 </div>
                                 <div class="setting-container vertical">
                                     <span>Image Render Scale</span>
-                                    <input type="range" id="render-scale" class="setting" setting="render-scale" min="1" max="5" step="1" data-format="x%s Scale">
+                                    <input type="range" id="render-scale" class="setting" setting="render-scale" min="1" max="10" step="1" data-format="x%s Scale">
                                     <span id="render-scale-display" class="range-display">Infinite Scale</span>
                                     <span class="hint">Note: Image Render Scale only works with "Copy Image" and "Download Image" buttons for now</span>
                                 </div>

--- a/scripts.js
+++ b/scripts.js
@@ -960,7 +960,7 @@ class Settings {
         // image settings
         this._firstLineGap = this.loadBooleanSetting("first-line-gap", false, true);
         this._renderBackground = this.loadBooleanSetting("render-background", false, true);
-        this._renderScale = this.loadNumberSetting("render-scale", true, 1, 1, 10);
+        this._renderScale = this.loadNumberSetting("render-scale", true, 2, 1, 10);
         this._fontVersion = this.loadNumberSetting("font-version", true, 0, 0, 1);
         // editor settings
         this._updatePeriod = this.loadNumberSetting("update-period", true, 2, 0, Number.MAX_SAFE_INTEGER);


### PR DESCRIPTION
# v0.6.3: Render Scaling
### Minor fix to #28 
- Changes the default render scale to 2x instead of 1x
- Increases the maximum render scale to 10x instead of 5x